### PR TITLE
Fix C# script compilation.

### DIFF
--- a/OMODFramework.Scripting/Scripting/DotNetScriptHandler.cs
+++ b/OMODFramework.Scripting/Scripting/DotNetScriptHandler.cs
@@ -46,6 +46,7 @@ namespace OMODFramework.Scripting
                 ReferencedAssemblies =
                 {
                     Framework.Settings.DllPath,
+                    System.IO.Path.Combine(System.IO.Path.GetDirectoryName(Framework.Settings.DllPath), "OMODFramework.Scripting.dll"),
                     "System.dll",
                     "System.Drawing.dll",
                     "System.Windows.Forms.dll",
@@ -69,6 +70,7 @@ namespace OMODFramework.Scripting
                     break;
                 case ScriptType.CSharp:
                     results = CSharpCompiler.CompileAssemblyFromSource(Params, code);
+                    
                     break;
                 case ScriptType.VB:
                     results = VBCompiler.CompileAssemblyFromSource(Params, code);


### PR DESCRIPTION
This probably isn't the best way to actually fix this, but it at least demonstrates what the problem was. If scripts are meant to link with the main framework DLL, it should probably forward stuff from the scripting DLL, and if they're meant to use the scripting DLL, the default value for the setting should be the scripting DLL, not the framework one. That would probably mean calling into the scripting DLL and having a function in that get the executing assembly.