### PR TITLE
Get compiler parameters which are based on settings each time they're used

### DIFF
--- a/OMODFramework.Scripting/Scripting/DotNetScriptHandler.cs
+++ b/OMODFramework.Scripting/Scripting/DotNetScriptHandler.cs
@@ -33,7 +33,14 @@ namespace OMODFramework.Scripting
         private static readonly CompilerParameters Params;
         private static readonly Evidence Evidence;
 
-        private static readonly string ScriptOutputPath = Path.Combine(Framework.Settings.TempPath, "dotnetscript.dll");
+        private static readonly string ScriptOutputName = "dotnetscript.dll";
+        private static readonly string[] ReferencedAssemblies =
+        {
+            "System.dll",
+            "System.Drawing.dll",
+            "System.Windows.Forms.dll",
+            "System.Xml.dll"
+        };
 
         static DotNetScriptHandler()
         {
@@ -41,16 +48,7 @@ namespace OMODFramework.Scripting
             {
                 GenerateExecutable = false,
                 GenerateInMemory = false,
-                IncludeDebugInformation = false,
-                OutputAssembly = ScriptOutputPath,
-                ReferencedAssemblies =
-                {
-                    Framework.Settings.DllPath,
-                    "System.dll",
-                    "System.Drawing.dll",
-                    "System.Windows.Forms.dll",
-                    "System.Xml.dll"
-                }
+                IncludeDebugInformation = false
             };
 
             Evidence = new Evidence();
@@ -60,6 +58,10 @@ namespace OMODFramework.Scripting
         private static byte[] Compile(string code, ScriptType type)
         {
             Utils.Debug("Starting compilation...");
+            Params.OutputAssembly = Path.Combine(Framework.Settings.TempPath, ScriptOutputName);
+            Params.ReferencedAssemblies.Clear();
+            Params.ReferencedAssemblies.Add(Framework.Settings.DllPath);
+            Params.ReferencedAssemblies.AddRange(ReferencedAssemblies);
             CompilerResults results = null;
             switch (type)
             {


### PR DESCRIPTION
Previously, the values that would get used would depend on the static initialisation order. If the user of the library set the settings after the class had loaded, the settings they set wouldn't get used, with the defaults being used instead. Also, if they changed the settings (e.g. if installing multiple OMODs with their own temp directory) the later values wouldn't get used.

This wasn't originally obvious, as .NET 4 made static initialisers super lazy, but given that Microsoft changed things in the past, they might want to change them again, and then everything would catch fire. This can't happen after this change.

I could have made it so that setting either of these settings updated the value used here (yay, properties), but I'm pretty sure that would have meant that setting the temp directory would force the scripting DLL to be loaded, and I don't think that's what was desired seeing as it's in a separate Nuget package.

Resolves https://github.com/erri120/OMODFramework/issues/31