### PR TITLE
Fixes for Sensual Walks

### DIFF
--- a/OMODFramework.Scripting/Scripting/OBMMScriptHandler.cs
+++ b/OMODFramework.Scripting/Scripting/OBMMScriptHandler.cs
@@ -825,12 +825,18 @@ namespace OMODFramework.Scripting
 
                 try
                 {
-                    var paths = Directory.GetDirectories(Path.Combine(root, line.ElementAt(4)),
-                        line.Count > 6 ? line.ElementAt(6) : "*", option);
+                    string[] paths;
+                    if (elementAt.EndsWith("Folder"))
+                        paths = Directory.GetDirectories(Path.Combine(root, line.ElementAt(4)), line.Count > 6 ? line.ElementAt(6) : "*", option);
+                    else
+                        paths = Directory.GetFiles(Path.Combine(root, line.ElementAt(4)), line.Count > 6 ? line.ElementAt(6) : "*", option);
                     for (var i = 0; i < paths.Length; i++)
                     {
                         if (Path.IsPathRooted(paths[i]))
+                        {
                             paths[i] = paths[i].Substring(root.Length);
+                            paths[i] = paths[i].TrimStart(Path.DirectorySeparatorChar);
+                        }
                     }
                     return new FlowControlStruct(paths, line.ElementAt(3), lineNo);
                 }

--- a/OMODFramework.Scripting/Scripting/SharedFunction.cs
+++ b/OMODFramework.Scripting/Scripting/SharedFunction.cs
@@ -1113,7 +1113,7 @@ namespace OMODFramework.Scripting
 
         public override void Run(ref IReadOnlyCollection<string> line)
         {
-            var plugin = line.ElementAt(0).StartsWith("Plugin");
+            var plugin = line.ElementAt(0).Contains("Plugin");
             FuncName = plugin ? "CopyPlugin" : "CopyDataFile";
 
             var from = line.ElementAt(1);


### PR DESCRIPTION
* Only get directories when directories have been requested (and get files when files have been requested).
* Remove leading backslashes from paths.
* Copy from the plugin store when copying plugins.