### PR TITLE
Actually install data files for OMODs that don't opt in or out

### DIFF
--- a/OMODFramework.Scripting/Scripting/DotNetScriptHandler.cs
+++ b/OMODFramework.Scripting/Scripting/DotNetScriptHandler.cs
@@ -48,17 +48,7 @@ namespace OMODFramework.Scripting
             {
                 GenerateExecutable = false,
                 GenerateInMemory = false,
-                IncludeDebugInformation = false,
-                OutputAssembly = ScriptOutputPath,
-                ReferencedAssemblies =
-                {
-                    Framework.Settings.DllPath,
-                    System.IO.Path.Combine(System.IO.Path.GetDirectoryName(Framework.Settings.DllPath), "OMODFramework.Scripting.dll"),
-                    "System.dll",
-                    "System.Drawing.dll",
-                    "System.Windows.Forms.dll",
-                    "System.Xml.dll"
-                }
+                IncludeDebugInformation = false
             };
 
             Evidence = new Evidence();

--- a/OMODFramework/Classes/Misc.cs
+++ b/OMODFramework/Classes/Misc.cs
@@ -330,7 +330,10 @@ namespace OMODFramework
             }
 
             if (InstallAllData)
+            {
+                omod.AllDataFiles.Do(d => filesData.Add(d.FileName));
                 omod.AllPlugins.Do(d => filesData.Add(d));
+            }
             InstallData.Where(d => !filesData.Contains(d)).Do(d => filesData.Add(d));
             filesData.RemoveWhere(d => IgnoreData.Contains(d));
 


### PR DESCRIPTION
I guess this got missed because most scripted OMODs call `DontInstallAnyDataFiles` and then opt into specific files or folders being installed, but I noticed that https://www.nexusmods.com/oblivion/mods/4922 (which is also the only OMOD I know of to register BSAs), but with `InstallAllData` set, only plugins were actually being installed.

This has been tested and resolved the issue I was seeing. It shouldn't cause any problems as the changed code only runs when it's supposed to, and happens before any files that *don't* need installing get removed from the list.